### PR TITLE
Fix formatting of currency on thank you page.

### DIFF
--- a/app/views/donations/show.html.erb
+++ b/app/views/donations/show.html.erb
@@ -1,6 +1,6 @@
 <h1>Thank you!</h1>
 <p>
-  Thank you for your donations of $<%= @donation.amount %>.
+  Thank you for your donation of <%= number_to_currency(@donation.amount) %>
 </p>
 <p>
   You'll be listed on our donors page as <%= @donation.donor_name %>


### PR DESCRIPTION
The donation about was not formatted as currency so it looked weird:

![techlahomadonations](https://cloud.githubusercontent.com/assets/209994/7784696/b7c6b69a-0134-11e5-885b-c395366a098a.png)

now it looks normal:

![techlahomadonations](https://cloud.githubusercontent.com/assets/209994/7784701/dfeca210-0134-11e5-9c38-5f3f747fe692.png)

This also changes the word "donations" to the singular "donation" since this page only shows a single donation by a patron.